### PR TITLE
Set displayName

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function updateFocus(currentState) {
 
 function withNavigationFocus(WrappedComponent) {
 
-  return class extends React.Component {
+  class WithNavigationFocus extends React.Component {
     static propTypes = {
       navigation: PropTypes.object.isRequired
     }
@@ -73,6 +73,10 @@ function withNavigationFocus(WrappedComponent) {
       );
     }
   }
+  WithNavigationFocus.displayName =
+    WrappedComponent.displayName || WrappedComponent.name || 'Component';
+
+  return WithNavigationFocus;
 }
 
 module.exports = {


### PR DESCRIPTION
Hi @patlux ! Thanks for providing this updated version of the HOC, we've found it very useful. We were wondering if you'd accept this PR to make reading snapshots and debugging slightly easier. It prevents things like this:
```
    - Snapshot
    + Received
    
    -<Connect(MyComponent)
    +<Connect(_class)
       propOne="1"
     />
```
See https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging for the docs.